### PR TITLE
cifsd: rework extract_sharename() and convert_delimiter()

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -270,19 +270,17 @@ void convert_delimiter(char *path, int flags)
  */
 char *extract_sharename(char *treename)
 {
-	int len;
+	char *name = treename;
 	char *dst;
+	char *pos = strrchr(name, '\\');
 
-	/* skip double chars at the beginning */
-	while (strchr(treename, '\\'))
-		strsep(&treename, "\\");
-	len = strlen(treename);
+	if (pos)
+		name = (pos + 1);
 
 	/* caller has to free the memory */
-	dst = kstrndup(treename, len, GFP_KERNEL);
+	dst = kstrdup(name, GFP_KERNEL);
 	if (!dst)
 		return ERR_PTR(-ENOMEM);
-
 	return dst;
 }
 

--- a/misc.c
+++ b/misc.c
@@ -226,7 +226,7 @@ char *convert_to_nt_pathname(char *filename, char *sharepath)
 	len = strlen(sharepath);
 	if (!strncmp(filename, sharepath, len) && strlen(filename) != len) {
 		strcpy(ab_pathname, &filename[len]);
-		convert_delimiter(ab_pathname, 1);
+		cifsd_conv_path_to_windows(ab_pathname);
 	}
 
 	return ab_pathname;
@@ -243,23 +243,23 @@ int get_nlink(struct kstat *st)
 	return nlink;
 }
 
-/**
- * convert_delimiter() - convert windows path to unix format or unix format
- *			 to windos path
- * @path:	path to be converted
- * @flags:	1 is to convert windows, 2 is to convert unix
- *
- */
-void convert_delimiter(char *path, int flags)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)
+static void strreplace(char *s, char old, char new)
 {
-	char *pos = path;
+	for (; *s; ++s)
+		if (*s == old)
+			*s = new;
+}
+#endif
 
-	if (flags == 1)
-		while ((pos = strchr(pos, '/')))
-			*pos = '\\';
-	else
-		while ((pos = strchr(pos, '\\')))
-			*pos = '/';
+void cifsd_conv_path_to_unix(char *path)
+{
+	strreplace(path, '\\', '/');
+}
+
+void cifsd_conv_path_to_windows(char *path)
+{
+	strreplace(path, '/', '\\');
 }
 
 /**

--- a/misc.h
+++ b/misc.h
@@ -24,7 +24,8 @@ char *convert_to_nt_pathname(char *filename, char *sharepath);
 
 int get_nlink(struct kstat *st);
 
-void convert_delimiter(char *path, int flags);
+void cifsd_conv_path_to_unix(char *path);
+void cifsd_conv_path_to_windows(char *path);
 
 char *extract_sharename(char *treename);
 

--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -584,7 +584,7 @@ smb_get_name(struct cifsd_share_config *share, const char *src, const int maxlen
 	}
 
 	/* change it to absolute unix name */
-	convert_delimiter(name, 0);
+	cifsd_conv_path_to_unix(name);
 	/*Handling of dir path in FIND_FIRST2 having '*' at end of path*/
 	wild_card_pos = strrchr(name, '*');
 
@@ -645,7 +645,7 @@ static char *smb_get_dir_name(struct cifsd_share_config *share, const char *src,
 	}
 
 	/* change it to absolute unix name */
-	convert_delimiter(name, 0);
+	cifsd_conv_path_to_unix(name);
 
 	pattern_pos = strrchr(name, '/');
 

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -611,7 +611,7 @@ smb2_get_name(struct cifsd_share_config *share,
 	}
 
 	/* change it to absolute unix name */
-	convert_delimiter(name, 0);
+	cifsd_conv_path_to_unix(name);
 
 	unixname = convert_to_unix_name(share, name);
 	kfree(name);


### PR DESCRIPTION
extract_sharename() is not very inefficient. For every treename
it does
	while (strchr(treename, '\\'))
		strsep(&treename, "\\");

So, for example, for treename '\\localhost\IPC$', it scans treename
from the start, finds the first \, invokes strsep(), which scans
treename from the start and updates the treename pointer the position
of the first \. Then it repeats whe whole thing for the second \
and for the last \, until it find the IPC$.

We don't have to do that. We can call strchr() just once, to find
the last \, and be done with the whole thing. No loops, no strsep().

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>