### PR TITLE
cifsd: get rid of __constant_cpu_to_leXX

### DIFF
--- a/smb1pdu.h
+++ b/smb1pdu.h
@@ -37,7 +37,7 @@
 #define NATIVE_FILE_SYSTEM	"NTFS"
 
 #define SMB_NO_MORE_ANDX_COMMAND 0xFF
-#define SMB1_PROTO_NUMBER __constant_cpu_to_le32(0x424d53ff)
+#define SMB1_PROTO_NUMBER cpu_to_le32(0x424d53ff)
 
 /* Transact2 subcommand codes */
 #define TRANS2_OPEN                   0x00

--- a/smb2pdu.h
+++ b/smb2pdu.h
@@ -78,11 +78,11 @@
 /* BB FIXME - analyze following length BB */
 #define MAX_SMB2_HDR_SIZE 0x78 /* 4 len + 64 hdr + (2*24 wct) + 2 bct + 2 pad */
 
-#define SMB2_PROTO_NUMBER __constant_cpu_to_le32(0x424d53fe) /* 'B''M''S' */
+#define SMB2_PROTO_NUMBER cpu_to_le32(0x424d53fe) /* 'B''M''S' */
 #define SMB2_TRANSFORM_PROTO_NUM cpu_to_le32(0x424d53fd)
 
-#define STATUS_NO_MORE_FILES __constant_cpu_to_le32(0x80000006)
-#define STATUS_OBJECT_NAME_NOT_FOUND __constant_cpu_to_le32(0xC0000034)
+#define STATUS_NO_MORE_FILES cpu_to_le32(0x80000006)
+#define STATUS_OBJECT_NAME_NOT_FOUND cpu_to_le32(0xC0000034)
 /*
  * SMB2 Header Definition
  *
@@ -94,7 +94,7 @@
 
 #define __SMB2_HEADER_STRUCTURE_SIZE	64
 #define SMB2_HEADER_STRUCTURE_SIZE				\
-	__constant_cpu_to_le16(__SMB2_HEADER_STRUCTURE_SIZE)
+	cpu_to_le16(__SMB2_HEADER_STRUCTURE_SIZE)
 
 struct smb2_hdr {
 	__be32 smb2_buf_length;	/* big endian on wire */
@@ -146,12 +146,12 @@ struct smb2_transform_hdr {
 /*
  *	SMB2 flag definitions
  */
-#define SMB2_FLAGS_SERVER_TO_REDIR	__constant_cpu_to_le32(0x00000001)
-#define SMB2_FLAGS_ASYNC_COMMAND	__constant_cpu_to_le32(0x00000002)
-#define SMB2_FLAGS_RELATED_OPERATIONS	__constant_cpu_to_le32(0x00000004)
-#define SMB2_FLAGS_SIGNED		__constant_cpu_to_le32(0x00000008)
-#define SMB2_FLAGS_DFS_OPERATIONS	__constant_cpu_to_le32(0x10000000)
-#define SMB2_FLAGS_REPLAY_OPERATIONS	__constant_cpu_to_le32(0x20000000)
+#define SMB2_FLAGS_SERVER_TO_REDIR	cpu_to_le32(0x00000001)
+#define SMB2_FLAGS_ASYNC_COMMAND	cpu_to_le32(0x00000002)
+#define SMB2_FLAGS_RELATED_OPERATIONS	cpu_to_le32(0x00000004)
+#define SMB2_FLAGS_SIGNED		cpu_to_le32(0x00000008)
+#define SMB2_FLAGS_DFS_OPERATIONS	cpu_to_le32(0x10000000)
+#define SMB2_FLAGS_REPLAY_OPERATIONS	cpu_to_le32(0x20000000)
 
 /*
  *	Definitions for SMB2 Protocol Data Units (network frames)
@@ -162,7 +162,7 @@ struct smb2_transform_hdr {
  *
  */
 
-#define SMB2_ERROR_STRUCTURE_SIZE2 __constant_cpu_to_le16(9)
+#define SMB2_ERROR_STRUCTURE_SIZE2 cpu_to_le16(9)
 
 struct smb2_err_rsp {
 	struct smb2_hdr hdr;
@@ -616,12 +616,12 @@ struct create_disk_id_rsp {
 	__u8  Reserved[16];
 } __packed;
 
-#define SMB2_LEASE_NONE			__constant_cpu_to_le32(0x00)
-#define SMB2_LEASE_READ_CACHING		__constant_cpu_to_le32(0x01)
-#define SMB2_LEASE_HANDLE_CACHING	__constant_cpu_to_le32(0x02)
-#define SMB2_LEASE_WRITE_CACHING	__constant_cpu_to_le32(0x04)
+#define SMB2_LEASE_NONE			cpu_to_le32(0x00)
+#define SMB2_LEASE_READ_CACHING		cpu_to_le32(0x01)
+#define SMB2_LEASE_HANDLE_CACHING	cpu_to_le32(0x02)
+#define SMB2_LEASE_WRITE_CACHING	cpu_to_le32(0x04)
 
-#define SMB2_LEASE_FLAG_BREAK_IN_PROGRESS __constant_cpu_to_le32(0x02)
+#define SMB2_LEASE_FLAG_BREAK_IN_PROGRESS cpu_to_le32(0x02)
 
 struct lease_context {
 	__le64 LeaseKeyLow;


### PR DESCRIPTION
Both cpu_to_le32 and cpu_to_le16 are capable to recognize compile
time constant and to avoid runtime overhead of swapXXb. So we can
use them instead of __constant_cpu_to_leXX.

Example:

\#define __swahb32(x)				\
	(__builtin_constant_p((__u32)(x)) ?	\
	___constant_swahb32(x) :		\
	__fswahb32(x))

static __always_inline __u32 __swab32p(const __u32 *p)
{
\#ifdef __arch_swab32p
	return __arch_swab32p(p);
\#else
	return __swab32(*p);
\#endif
}

static __always_inline __le32 __cpu_to_le32p(const __u32 *p)
{
	return (__force __le32)__swab32p(p);
}

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>