### PR TITLE
cifsd: disable stream support at default

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -35,6 +35,7 @@
 
 bool multi_channel_enable;
 bool encryption_enable;
+bool stream_file_enable;
 
 /**
  * check_session_id() - check for valid session id in smb header
@@ -2080,6 +2081,10 @@ int smb2_open(struct cifsd_work *work)
 
 	cifsd_debug("converted name = %s\n", name);
 	if (strchr(name, ':')) {
+		if (stream_file_enable == false) {
+			rc = -EBADF;
+			goto err_out1;
+		}
 		rc = parse_stream_name(name, &stream_name, &s_type);
 		if (rc < 0)
 			goto err_out1;


### PR DESCRIPTION
When downloading file through internet browser, windows open stream
file and try to read with big offset and size. It cause read failure
or kernel oops. Need to look into more.
For now, disable stream support at default like samba.

Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>