### PR TITLE
cifsd: add interfaces parameter

### DIFF
--- a/cifsd_server.h
+++ b/cifsd_server.h
@@ -21,6 +21,8 @@
 #define CIFSD_REQ_MAX_HASH_SZ		18
 #define CIFSD_REQ_MAX_SHARE_NAME	64
 
+#define CIFSD_STARTUP_CONFIG_INTERFACES(s)      ((s)->____payload)
+
 struct cifsd_heartbeat {
 	__u32	handle;
 } __align;
@@ -34,6 +36,7 @@ struct cifsd_startup_request {
 	__s8	server_string[64];
 	__u16	tcp_port;
 	__u16	ipc_timeout;
+	__s8    ____payload[0];
 } __align;
 
 struct cifsd_shutdown_request {

--- a/server.h
+++ b/server.h
@@ -17,17 +17,23 @@
 
 extern int cifsd_debugging;
 
-struct cifsd_server_config {
-	int		state;
-	char		*conf[SERVER_CONF_WORK_GROUP + 1];
+struct interface {
+	struct list_head	entry;
+	char			*name;
+};
 
-	short		signing;
-	short		enforced_signing;
-	short		min_protocol;
-	short		max_protocol;
-	unsigned short	tcp_port;
-	unsigned short	ipc_timeout;
-	unsigned long	ipc_last_active;
+struct cifsd_server_config {
+	int			state;
+	char			*conf[SERVER_CONF_WORK_GROUP + 1];
+
+	short			signing;
+	short			enforced_signing;
+	short			min_protocol;
+	short			max_protocol;
+	unsigned short		tcp_port;
+	unsigned short		ipc_timeout;
+	unsigned long		ipc_last_active;
+	struct list_head	iface_list;
 };
 
 extern struct cifsd_server_config server_conf;
@@ -35,6 +41,7 @@ extern struct cifsd_server_config server_conf;
 int cifsd_set_netbios_name(char *v);
 int cifsd_set_server_string(char *v);
 int cifsd_set_work_group(char *v);
+int cifsd_set_interfaces(char *v);
 
 char *cifsd_netbios_name(void);
 char *cifsd_server_string(void);

--- a/transport_ipc.c
+++ b/transport_ipc.c
@@ -285,6 +285,7 @@ static int ipc_server_config_on_startup(struct cifsd_startup_request *req)
 	ret = cifsd_set_netbios_name(req->netbios_name);
 	ret |= cifsd_set_server_string(req->server_string);
 	ret |= cifsd_set_work_group(req->work_group);
+	ret |= cifsd_set_interfaces(CIFSD_STARTUP_CONFIG_INTERFACES(req));
 	if (ret) {
 		cifsd_err("Server configuration error: %s %s %s\n",
 				req->netbios_name,


### PR DESCRIPTION
Add interfaces parameter to allow connection of specific device in server.
Use match_pattern to consider "eth*" in interfaces.

Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>