### PR TITLE
cifsd: keep header flags in le

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -339,7 +339,7 @@ static void init_chained_smb2_rsp(struct cifsd_work *work)
 	rcv_hdr = (struct smb2_hdr *)(((char *)REQUEST_BUF(work) +
 					work->next_smb2_rcv_hdr_off));
 
-	if (!(le32_to_cpu(rcv_hdr->Flags) & SMB2_FLAGS_RELATED_OPERATIONS)) {
+	if (!(rcv_hdr->Flags & SMB2_FLAGS_RELATED_OPERATIONS)) {
 		cifsd_debug("related flag should be set\n");
 		work->compound_fid = CIFSD_NO_FID;
 		work->compound_pfid = CIFSD_NO_FID;
@@ -504,7 +504,7 @@ void smb2_set_rsp_credits(struct cifsd_work *work)
 	struct smb2_hdr *hdr = (struct smb2_hdr *)RESPONSE_BUF(work);
 	struct cifsd_tcp_conn *conn = work->conn;
 	unsigned int status = le32_to_cpu(hdr->Status);
-	unsigned int flags = le32_to_cpu(hdr->Flags);
+	unsigned int flags = hdr->Flags;
 	unsigned short credits_requested = le16_to_cpu(hdr->CreditRequest);
 	unsigned short cmd = le16_to_cpu(hdr->Command);
 	unsigned short credit_charge = 1, credits_granted = 0;
@@ -2198,8 +2198,7 @@ int smb2_open(struct cifsd_work *work)
 
 	if (le32_to_cpu(req->hdr.NextCommand) &&
 			!work->next_smb2_rcv_hdr_off &&
-			(le32_to_cpu(req->hdr.Flags) &
-			 SMB2_FLAGS_RELATED_OPERATIONS)) {
+			(req->hdr.Flags & SMB2_FLAGS_RELATED_OPERATIONS)) {
 		cifsd_debug("invalid flag in chained command\n");
 		rsp->hdr.Status = STATUS_INVALID_PARAMETER;
 		smb2_set_err_rsp(work);
@@ -4441,8 +4440,7 @@ int smb2_close(struct cifsd_work *work)
 	}
 
 	sess_id = le64_to_cpu(req->hdr.SessionId);
-	if (le32_to_cpu(req->hdr.Flags) &
-			SMB2_FLAGS_RELATED_OPERATIONS)
+	if (req->hdr.Flags & SMB2_FLAGS_RELATED_OPERATIONS)
 		sess_id = work->compound_sid;
 
 	work->compound_sid = 0;
@@ -4450,8 +4448,7 @@ int smb2_close(struct cifsd_work *work)
 		work->compound_sid = sess_id;
 	else {
 		rsp->hdr.Status = STATUS_USER_SESSION_DELETED;
-		if (le32_to_cpu(req->hdr.Flags) &
-				SMB2_FLAGS_RELATED_OPERATIONS)
+		if (req->hdr.Flags & SMB2_FLAGS_RELATED_OPERATIONS)
 			rsp->hdr.Status = STATUS_INVALID_PARAMETER;
 		err = -EBADF;
 		goto out;


### PR DESCRIPTION
SMB2_FLAGS_RELATED_OPERATIONS and a bunch of other defines are
in cpu_to_le32/16, so are header flags. Casting header flags
to host endianness is not exactly correct:

  le32_to_cpu(req->hdr.Flags) & SMB2_FLAGS_RELATED_OPERATIONS

On BE system this will become

	BE(flags) & LE(SMB2_FLAGS_RELATED_OPERATIONS)

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>