### PR TITLE
cifsd: convert compound session id to cpu

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -314,7 +314,7 @@ static void init_chained_smb2_rsp(struct cifsd_work *work)
 		work->compound_pfid =
 			le64_to_cpu(((struct smb2_create_rsp *)rsp)->
 				PersistentFileId);
-		work->compound_sid = rsp->SessionId;
+		work->compound_sid = le64_to_cpu(rsp->SessionId);
 	}
 
 	len = get_rfc1002_length(RESPONSE_BUF(work)) -


### PR DESCRIPTION
When commanding df -h, cifs send compound request(open->get_info->close).
But compound_sid is not converted to cpu from le64, So may not get failure
from df -h result.

Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>