### PR TITLE
cifsd: not require to convert le in smb1 command

### DIFF
--- a/smb1misc.c
+++ b/smb1misc.c
@@ -44,7 +44,7 @@ static int smb1_req_struct_size(struct smb_hdr *hdr)
 {
 	int wc = hdr->WordCount;
 
-	switch (le16_to_cpu(hdr->Command)) {
+	switch (hdr->Command) {
 	case SMB_COM_CREATE_DIRECTORY:
 	case SMB_COM_DELETE_DIRECTORY:
 	case SMB_COM_QUERY_INFORMATION:


### PR DESCRIPTION
Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>