### PR TITLE
cifsd: fix compilation on kernel 4.19

### DIFF
--- a/unicode.c
+++ b/unicode.c
@@ -8,7 +8,7 @@
  */
 #include <linux/fs.h>
 #include <linux/slab.h>
-#include <asm-generic/unaligned.h>
+#include <asm/unaligned.h>
 #include "unicode.h"
 #include "uniupr.h"
 #include "glob.h"


### PR DESCRIPTION
When I tried building cifsd against kernel 4.19, I encountered some redefinition errors:
```
  CC [M]  /opt/openwrt/build_dir/target-arm_cortex-a9+neon_musl_eabi/linux-mvebu_cortexa9/cifsd-2019-03-28-290162b6/unicode.o
In file included from ./arch/arm/include/asm/unaligned.h:12:0,
                 from ./include/linux/etherdevice.h:28,
                 from ./include/linux/if_vlan.h:16,
                 from ./include/linux/filter.h:22,
                 from ./include/net/sock.h:64,
                 from /opt/openwrt/build_dir/target-arm_cortex-a9+neon_musl_eabi/linux-mvebu_cortexa9/cifsd-2019-03-28-290162b6/glob.h:16,
                 from /opt/openwrt/build_dir/target-arm_cortex-a9+neon_musl_eabi/linux-mvebu_cortexa9/cifsd-2019-03-28-290162b6/unicode.c:14:
./include/linux/unaligned/le_struct.h:7:19: error: redefinition of 'get_unaligned_le16'
 static inline u16 get_unaligned_le16(const void *p)
                   ^~~~~~~~~~~~~~~~~~
In file included from ./include/asm-generic/unaligned.h:13:0,
                 from /opt/openwrt/build_dir/target-arm_cortex-a9+neon_musl_eabi/linux-mvebu_cortexa9/cifsd-2019-03-28-290162b6/unicode.c:11:
./include/linux/unaligned/access_ok.h:8:28: note: previous definition of 'get_unaligned_le16' was here
 static __always_inline u16 get_unaligned_le16(const void *p)
                            ^~~~~~~~~~~~~~~~~~
```
Replacing `asm-generic/unaligned.h` with `asm/unaligned.h` fixed this error