### PR TITLE
cifsd: don't send status pending in smb2 notify response

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -6887,19 +6887,8 @@ int smb2_notify(struct cifsd_work *cifsd_work)
 		return 0;
 	}
 
-	/*
-	 * Win7 send peoridically query_dir command if cifsd just response
-	 * with STATUS_NOT_IMPLEMENTED status. If SMB2_WATCH_TREE flags
-	 * is set in change notify command, cifsd send async response with
-	 * STATUS PENDING to avoid peoridical query_dir.
-	 */
-	if (le16_to_cpu(req->Flags) == SMB2_WATCH_TREE) {
-		smb2_send_interim_resp(cifsd_work, STATUS_PENDING);
-		cifsd_work->send_no_response = 1;
-	} else {
-		smb2_set_err_rsp(cifsd_work);
-		rsp->hdr.Status = STATUS_NOT_IMPLEMENTED;
-	}
+	smb2_set_err_rsp(cifsd_work);
+	rsp->hdr.Status = STATUS_NOT_IMPLEMENTED;
 
 	return 0;
 }


### PR DESCRIPTION
Altough smb2 notify is not implemented, we response status pending in smb2
notify. Not sure previous behavior is changed by windows 7 update.
And Rosen reported watching error happen by this code with foobar2000 app.

Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>
Cc: Rosen Penev <rosenp@gmail.com>