### PR TITLE
cifsd: fix racy issue after removing cifsd_tcp_conn_lock

### DIFF
--- a/smb2ops.c
+++ b/smb2ops.c
@@ -207,7 +207,7 @@ int init_smb2_0_server(struct cifsd_tcp_conn *conn)
 	conn->cmds = smb2_0_server_cmds;
 	conn->max_cmds = ARRAY_SIZE(smb2_0_server_cmds);
 	conn->max_credits = SMB2_MAX_CREDITS;
-	conn->credits_granted = 0;
+	atomic_set(&conn->total_credits, 0);
 	conn->srv_cap = 0;
 	return 0;
 }

--- a/smb_common.c
+++ b/smb_common.c
@@ -289,7 +289,7 @@ int cifsd_init_smb_server(struct cifsd_work *work)
 	void *buf = REQUEST_BUF(work);
 	int proto;
 
-	if (!conn->need_neg)
+	if (!atomic_read(&conn->need_neg))
 		return 0;
 
 	proto = *(__le32 *)((struct smb_hdr *)buf)->Protocol;
@@ -301,7 +301,7 @@ int cifsd_init_smb_server(struct cifsd_work *work)
 	}
 
 	if (conn->ops->get_cmd_val(work) != SMB_COM_NEGOTIATE)
-		conn->need_neg = false;
+		atomic_set(&conn->need_neg, 0);
 	return 0;
 }
 
@@ -514,7 +514,7 @@ int cifsd_smb_negotiate_common(struct cifsd_work *work, unsigned int command)
 
 	if (command == SMB_COM_NEGOTIATE) {
 		if (__smb2_negotiate(conn)) {
-			conn->need_neg = true;
+			atomic_set(&conn->need_neg, 1);
 			cifsd_init_smb2_server_common(conn);
 			init_smb2_neg_rsp(work);
 			cifsd_debug("Upgrade to SMB2 negotiation\n");

--- a/transport_tcp.c
+++ b/transport_tcp.c
@@ -109,7 +109,7 @@ static struct cifsd_tcp_conn *cifsd_tcp_conn_alloc(struct socket *sock)
 	if (!conn)
 		return NULL;
 
-	conn->need_neg = true;
+	atomic_set(&conn->need_neg, 1);
 	conn->tcp_status = CIFSD_SESS_NEW;
 	conn->sock = sock;
 	conn->local_nls = load_nls("utf8");
@@ -118,7 +118,7 @@ static struct cifsd_tcp_conn *cifsd_tcp_conn_alloc(struct socket *sock)
 	atomic_set(&conn->req_running, 0);
 	atomic_set(&conn->r_count, 0);
 	conn->max_credits = 0;
-	conn->credits_granted = 0;
+	atomic_set(&conn->total_credits, 0);
 	init_waitqueue_head(&conn->req_running_q);
 	INIT_LIST_HEAD(&conn->tcp_conns);
 	INIT_LIST_HEAD(&conn->sessions);

--- a/transport_tcp.h
+++ b/transport_tcp.h
@@ -78,13 +78,14 @@ struct cifsd_tcp_conn {
 	atomic_t			req_running;
 	/* References which are made for this Server object*/
 	atomic_t			r_count;
+	atomic_t			need_neg;
+	atomic_t			total_credits;
 	wait_queue_head_t		req_running_q;
 	/* Lock to protect requests list*/
 	spinlock_t			request_lock;
 	struct list_head		requests;
 	struct list_head		async_requests;
 	int				max_credits;
-	int				credits_granted;
 	int				connection_type;
 	struct cifsd_stats		stats;
 	char				ClientGUID[SMB2_CLIENT_GUID_SIZE];
@@ -107,7 +108,6 @@ struct cifsd_tcp_conn {
 	/* Supports legacy MS Kerberos */
 	bool				sec_mskerberos;
 	bool				sign;
-	bool				need_neg;
 	bool				use_spnego:1;
 	__u16				cli_sec_mode;
 	__u16				srv_sec_mode;


### PR DESCRIPTION
[1-176.4036] kcifsd: init_smb2_rsp_hdr:441: conn->credits_granted : 2, credit charge : 16
[1-176.4061] kcifsd: init_smb2_rsp_hdr:441: conn->credits_granted : -14, credit charge : 1
[1-176.4140] kcifsd: smb2_set_rsp_credits:552: credits: requested[0] granted[0] total_granted[-15]

conn->total_credits have been racy since reducing tcp conn lock scope.
This patch change conn->total_credits to atomic variable.

Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>