### PR TITLE
cifsd: add async request entry

### DIFF
--- a/glob.h
+++ b/glob.h
@@ -169,6 +169,8 @@ struct cifsd_work {
 
 	/* List head at conn->requests */
 	struct list_head		request_entry;
+	/* List head at conn->async_requests */
+	struct list_head		async_request_entry;
 	struct work_struct		work;
 
 	/* cancel works */

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -664,9 +664,7 @@ int setup_async_work(struct cifsd_work *work, void (*fn)(void **), void **arg)
 	work->cancel_argv = arg;
 
 	spin_lock(&conn->request_lock);
-	list_del_init(&work->request_entry);
-	list_add_tail(&work->request_entry,
-		&conn->async_requests);
+	list_add_tail(&work->async_request_entry, &conn->async_requests);
 	spin_unlock(&conn->request_lock);
 
 	return 0;
@@ -5628,37 +5626,50 @@ int smb2_cancel(struct cifsd_work *work)
 	int canceled = 0;
 	struct list_head *command_list;
 
-	cifsd_debug("smb2 cancel called on mid %llu\n", hdr->MessageId);
+	cifsd_debug("smb2 cancel called on mid %llu, async flags 0x%x\n",
+		hdr->MessageId, hdr->Flags);
 
-	if (hdr->Flags & SMB2_FLAGS_ASYNC_COMMAND)
+	if (hdr->Flags & SMB2_FLAGS_ASYNC_COMMAND) {
 		command_list = &conn->async_requests;
-	else
-		command_list = &conn->requests;
 
-	spin_lock(&conn->request_lock);
-	list_for_each(tmp, command_list) {
-		cancel_work = list_entry(tmp, struct cifsd_work,
-				request_entry);
-		chdr = (struct smb2_hdr *)REQUEST_BUF(cancel_work);
-		if (cancel_work->type == ASYNC) {
+		spin_lock(&conn->request_lock);
+		list_for_each(tmp, command_list) {
+			cancel_work = list_entry(tmp, struct cifsd_work,
+					async_request_entry);
+			chdr = (struct smb2_hdr *)REQUEST_BUF(cancel_work);
+
 			if (cancel_work->async_id !=
 					le64_to_cpu(hdr->Id.AsyncId))
 				continue;
+
 			cifsd_debug("smb2 with AsyncId %llu cancelled command = 0x%x\n",
 				le64_to_cpu(hdr->Id.AsyncId),
 				le16_to_cpu(chdr->Command));
-		} else {
+			canceled = 1;
+			break;
+		}
+		spin_unlock(&conn->request_lock);
+	} else {
+		command_list = &conn->requests;
+
+		spin_lock(&conn->request_lock);
+		list_for_each(tmp, command_list) {
+			cancel_work = list_entry(tmp, struct cifsd_work,
+					request_entry);
+			chdr = (struct smb2_hdr *)REQUEST_BUF(cancel_work);
+
 			if (chdr->MessageId != hdr->MessageId ||
 				cancel_work == work)
 				continue;
+
 			cifsd_debug("smb2 with mid %llu cancelled command = 0x%x\n",
 				le64_to_cpu(hdr->MessageId),
 				le16_to_cpu(chdr->Command));
+			canceled = 1;
+			break;
 		}
-		canceled = 1;
-		break;
+		spin_unlock(&conn->request_lock);
 	}
-	spin_unlock(&conn->request_lock);
 
 	if (canceled) {
 		cancel_work->state = WORK_STATE_CANCELLED;

--- a/transport_tcp.c
+++ b/transport_tcp.c
@@ -745,6 +745,9 @@ int cifsd_tcp_try_dequeue_request(struct cifsd_work *work)
 	spin_lock(&conn->request_lock);
 	if (!work->multiRsp) {
 		list_del_init(&work->request_entry);
+		if (work->type == ASYNC)
+			list_del_init(&work->async_request_entry);
+
 		work->on_request_list = 0;
 		ret = 0;
 	}


### PR DESCRIPTION
According to the current setup_async_work() operation, a request_entry
can be set in either conn->requests or conn->async_requests.
But, SMB2 CANCEL Request can have both set or not set of
SMB2_FLAGS_ASYNC_COMMAND to cancel the previous async request.
So, add async_request_entry and manage the sync/async list simultaneously.

Signed-off-by: Yunjae Lim <yunjae.lim@samsung.com>