### PR TITLE
cifsd: fix compilation on kernel v4.16

### DIFF
--- a/transport_tcp.c
+++ b/transport_tcp.c
@@ -312,7 +312,7 @@ static int cifsd_tcp_new_connection(struct socket *client_sk)
 
 	csin = CIFSD_TCP_PEER_SOCKADDR(conn);
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(4, 16, 0)
 	if (kernel_getpeername(client_sk, csin, &rc) < 0) {
 		cifsd_err("client ip resolution failed\n");
 		rc = -EINVAL;


### PR DESCRIPTION
The prototype of kernel_getpeername was changed
from kernel v4.17

Signed-off-by: Hyunchul Lee <hyc.lee@gmail.com>