### PR TITLE
cifsd: drop several paddings from struct oplock_info

### DIFF
--- a/oplock.h
+++ b/oplock.h
@@ -62,22 +62,22 @@ struct oplock_info {
 	struct cifsd_tcp_conn	*conn;
 	struct cifsd_session	*sess;
 	struct cifsd_work	*work;
-	bool			is_smb2;
 	struct cifsd_file	*o_fp;
 	int                     level;
 	int                     op_state;
 	uint64_t                fid;
-	__u16                   Tid;
 	atomic_t		breaking_cnt;
 	atomic_t		refcount;
+	__u16                   Tid;
 	bool			is_lease;
+	bool			is_smb2;
+	bool			open_trunc;	/* truncate on open */
 	struct lease		*o_lease;
 	struct list_head        interim_list;
 	struct list_head        op_entry;
 	struct list_head        lease_entry;
 	wait_queue_head_t oplock_q; /* Other server threads */
 	wait_queue_head_t oplock_brk; /* oplock breaking wait */
-	bool			open_trunc:1;	/* truncate on open */
 	struct rcu_head		rcu_head;
 };
 

--- a/smb_common.c
+++ b/smb_common.c
@@ -673,5 +673,5 @@ int cifsd_smb_check_shared_mode(struct file *filp, struct cifsd_file *curr_fp)
 
 bool is_asterisk(char *p)
 {
-	return p && !strcmp("*", p);
+	return p && p[0] == '*';
 }


### PR DESCRIPTION
add/remove: 0/0 grow/shrink: 0/9 up/down: 0/-77 (-77)
Function                                     old     new   delta
wait_for_lease_break_ack                     234     231      -3
smb_grant_oplock                            2273    2270      -3
smb_break_all_oplock                         165     162      -3
smb2_oplock_break.cold                       534     531      -3
close_id_del_oplock                          250     247      -3
__smb1_oplock_break_noti                     280     277      -3
smb2_oplock_break                           1118    1112      -6
oplock_break                                1778    1755     -23
smb_break_all_levII_oplock                   428     398     -30
Total: Before=128753, After=128676, chg -0.06%

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>