### PR TITLE
cifsd: ss

### DIFF
--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -1211,8 +1211,8 @@ int smb_session_setup_andx(struct cifsd_work *work)
 			rc = -ENOENT;
 			goto out_err;
 		}
-		cifsd_debug("reuse session(%p) session ID : %llu, Uid : %u\n",
-			sess, sess->id, uid);
+		cifsd_debug("Reuse session ID: %llu, Uid: %u\n",
+			    sess->id, uid);
 	} else {
 		sess = cifsd_smb1_session_create();
 		if (!sess) {
@@ -1222,8 +1222,7 @@ int smb_session_setup_andx(struct cifsd_work *work)
 
 		cifsd_session_register(conn, sess);
 		rsp->resp.hdr.Uid = cpu_to_le16(sess->id);
-		cifsd_debug("generate session(%p) ID : %llu, Uid : %u\n",
-				sess, sess->id, uid);
+		cifsd_debug("New session ID: %llu, Uid: %u\n", sess->id, uid);
 	}
 
 	if (cap & CAP_EXTENDED_SECURITY) {

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -4745,14 +4745,14 @@ static int smb2_set_info_file(struct cifsd_work *work, struct cifsd_file *fp,
 
 		if (file_info->LastAccessTime) {
 			attrs.ia_atime = to_kern_timespec(cifs_NTtimeToUnix(
-					le64_to_cpu(file_info->LastAccessTime)));
+						file_info->LastAccessTime));
 			attrs.ia_valid |= (ATTR_ATIME | ATTR_ATIME_SET);
 		}
 
 		if (file_info->ChangeTime) {
 			temp_attrs.ia_ctime =
 				to_kern_timespec(cifs_NTtimeToUnix(
-					le64_to_cpu(file_info->ChangeTime)));
+						file_info->ChangeTime));
 			attrs.ia_ctime = temp_attrs.ia_ctime;
 			attrs.ia_valid |= ATTR_CTIME;
 		} else
@@ -4760,7 +4760,7 @@ static int smb2_set_info_file(struct cifsd_work *work, struct cifsd_file *fp,
 
 		if (file_info->LastWriteTime) {
 			attrs.ia_mtime = to_kern_timespec(cifs_NTtimeToUnix(
-					le64_to_cpu(file_info->LastWriteTime)));
+						file_info->LastWriteTime));
 			attrs.ia_valid |= (ATTR_MTIME | ATTR_MTIME_SET);
 		}
 

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -4727,7 +4727,7 @@ static int smb2_set_info_file(struct cifsd_work *work, struct cifsd_file *fp,
 		file_info = (struct smb2_file_all_info *)buffer;
 		attrs.ia_valid = 0;
 
-		if (le64_to_cpu(file_info->CreationTime)) {
+		if (file_info->CreationTime) {
 			fp->create_time = le64_to_cpu(file_info->CreationTime);
 			if (test_share_config_flag(share,
 					CIFSD_SHARE_FLAG_STORE_DOS_ATTRS)) {
@@ -4743,13 +4743,13 @@ static int smb2_set_info_file(struct cifsd_work *work, struct cifsd_file *fp,
 			}
 		}
 
-		if (le64_to_cpu(file_info->LastAccessTime)) {
+		if (file_info->LastAccessTime) {
 			attrs.ia_atime = to_kern_timespec(cifs_NTtimeToUnix(
 					le64_to_cpu(file_info->LastAccessTime)));
 			attrs.ia_valid |= (ATTR_ATIME | ATTR_ATIME_SET);
 		}
 
-		if (le64_to_cpu(file_info->ChangeTime)) {
+		if (file_info->ChangeTime) {
 			temp_attrs.ia_ctime =
 				to_kern_timespec(cifs_NTtimeToUnix(
 					le64_to_cpu(file_info->ChangeTime)));
@@ -4758,7 +4758,7 @@ static int smb2_set_info_file(struct cifsd_work *work, struct cifsd_file *fp,
 		} else
 			temp_attrs.ia_ctime = inode->i_ctime;
 
-		if (le64_to_cpu(file_info->LastWriteTime)) {
+		if (file_info->LastWriteTime) {
 			attrs.ia_mtime = to_kern_timespec(cifs_NTtimeToUnix(
 					le64_to_cpu(file_info->LastWriteTime)));
 			attrs.ia_valid |= (ATTR_MTIME | ATTR_MTIME_SET);

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -784,7 +784,7 @@ decode_encrypt_ctxt(struct cifsd_tcp_conn *conn,
 	struct smb2_encryption_neg_context *pneg_ctxt)
 {
 	int i;
-	int cph_cnt = pneg_ctxt->CipherCount;
+	int cph_cnt = le16_to_cpu(pneg_ctxt->CipherCount);
 
 	conn->CipherId = 0;
 

--- a/vfs.c
+++ b/vfs.c
@@ -1427,7 +1427,7 @@ void cifsd_vfs_smb2_sector_size(struct inode *inode,
  * Return:	0 on success, otherwise error
  */
 struct cifsd_file *cifsd_vfs_dentry_open(struct cifsd_work *work,
-	const struct path *path, int flags, int option, int fexist)
+	const struct path *path, int flags, __le32 option, int fexist)
 {
 	struct file *filp;
 	int err = 0;
@@ -1472,7 +1472,7 @@ err_out:
 struct cifsd_file *cifsd_vfs_dentry_open(struct cifsd_work *work,
 					 const struct path *path,
 					 int flags,
-					 int option,
+					 __le32 option,
 					 int fexist)
 {
 	return NULL;

--- a/vfs.h
+++ b/vfs.h
@@ -158,7 +158,7 @@ int cifsd_vfs_copy_file_ranges(struct cifsd_work *work,
 struct cifsd_file *cifsd_vfs_dentry_open(struct cifsd_work *work,
 					 const struct path *path,
 					 int flags,
-					 int option,
+					 __le32 option,
 					 int fexist);
 
 ssize_t cifsd_vfs_listxattr(struct dentry *dentry, char **list, int size);


### PR DESCRIPTION
pneg_ctxt->CipherCount is in le16. Using it in a loop on BE
system is not going to work. We need to convert it to CPU
native format first.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>