### PR TITLE
cifsd: add device name in forker thread name

### DIFF
--- a/transport_tcp.c
+++ b/transport_tcp.c
@@ -252,7 +252,7 @@ static int cifsd_tcp_run_kthread(struct interface *iface)
 	struct task_struct *kthread;
 
 	kthread = kthread_run(cifsd_kthread_fn, (void *)iface->cifsd_socket,
-		"kcifsd");
+		"kcifsd-%s", iface->name);
 	if (IS_ERR(kthread)) {
 		rc = PTR_ERR(kthread);
 		return rc;


### PR DESCRIPTION
Can see:
  239 ?        S      0:00 [kcifsd-eth0]
  240 ?        S      0:00 [kcifsd-lo]

Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>