### PR TITLE
cifsd: add reference count to cifsd_fp

### DIFF
--- a/oplock.c
+++ b/oplock.c
@@ -708,6 +708,7 @@ static void __smb2_oplock_break_noti(struct work_struct *wk)
 	if (conn->ops->allocate_rsp_buf(work)) {
 		cifsd_err("smb2_allocate_rsp_buf failed! ");
 		cifsd_free_work_struct(work);
+		cifsd_fd_put(work, fp);
 		return;
 	}
 
@@ -746,6 +747,7 @@ static void __smb2_oplock_break_noti(struct work_struct *wk)
 	cifsd_debug("sending oplock break v_id %llu p_id = %llu lock level = %d\n",
 			rsp->VolatileFid, rsp->PersistentFid, rsp->OplockLevel);
 
+	cifsd_fd_put(work, fp);
 	cifsd_conn_write(work);
 	cifsd_free_work_struct(work);
 }

--- a/vfs.c
+++ b/vfs.c
@@ -633,6 +633,7 @@ int cifsd_vfs_setattr(struct cifsd_work *work, const char *name,
 out:
 	if (name)
 		path_put(&path);
+	cifsd_fd_put(work, fp);
 	return err;
 }
 
@@ -666,6 +667,7 @@ int cifsd_vfs_getattr(struct cifsd_work *work, uint64_t fid,
 #endif
 	if (err)
 		cifsd_err("getattr failed for fid %llu, err %d\n", fid, err);
+	cifsd_fd_put(work, fp);
 	return err;
 }
 
@@ -836,7 +838,7 @@ int cifsd_vfs_fsync(struct cifsd_work *work, uint64_t fid, uint64_t p_id)
 	err = vfs_fsync(fp->filp, 0);
 	if (err < 0)
 		cifsd_err("smb fsync failed, err = %d\n", err);
-
+	cifsd_fd_put(work, fp);
 	return err;
 }
 

--- a/vfs_cache.h
+++ b/vfs_cache.h
@@ -81,6 +81,7 @@ struct cifsd_file {
 	struct cifsd_conn		*conn;
 	struct cifsd_tree_connect	*tcon;
 
+	atomic_t			refcount;
 	__le32				daccess;
 	__le32				saccess;
 	__le32				coption;
@@ -175,6 +176,8 @@ struct cifsd_file *cifsd_lookup_foreign_fd(struct cifsd_work *work,
 struct cifsd_file *cifsd_lookup_fd_slow(struct cifsd_work *work,
 					unsigned int id,
 					unsigned int pid);
+
+void cifsd_fd_put(struct cifsd_work *work, struct cifsd_file *fp);
 
 struct cifsd_file *cifsd_lookup_durable_fd(unsigned long long id);
 struct cifsd_file *cifsd_lookup_fd_app_id(char *app_id);


### PR DESCRIPTION
Work in progress. Initial patch for SMB2.
No SMB1 support yet, no durable fp-s handling yet.

Apparently we can have parallel vfs_cache operations
within one connection, cifsd file is not ready for that.

kworker/4:0 CPU 4 kcifsd: __cifsd_close_fd() FD->volatile_id == 0
  kworker/0:3 CPU 0 kcifsd: smb2_get_info_file() FD->volatile_id == 0
  kworker/0:3 CPU 0 kcifsd: __cifsd_lookup_fd() FD->volatile_id == 0
  kworker/0:3 CPU 0 kcifsd: get_file_all_info() FD->volatile_id == 0
kworker/4:0 CPU 4 kcifsd: __cifsd_close_fd() kfree() FD->volatile_id == 0
 kworker/0:3 CPU 0 BUG: kernel NULL pointer dereference

[  146.622912] BUG: kernel NULL pointer dereference, address: 000000000000064c
[  146.622915] #PF: supervisor read access in kernel mode
[  146.622919] #PF: error_code(0x0000) - not-present page
[  146.622959] Workqueue: events handle_cifsd_work [cifsd]
[  146.622986] RIP: 0010:get_file_all_info.isra.0+0x17d/0x566 [cifsd]
[  146.623029] Call Trace:
[  146.623035]  ? irq_work_claim+0x2e/0x50
[  146.623062]  ? smb2_set_stream_name_xattr.isra.0.cold+0x46/0x46 [cifsd]
[  146.623068]  ? irq_work_queue+0xb/0x30
[  146.623073]  ? wake_up_klogd+0x37/0x40
[  146.623076]  ? vprintk_emit+0xf9/0x280
[  146.623081]  ? printk+0x96/0xb2
[  146.623085]  ? kmsg_dump_rewind+0xa5/0xa5
[  146.623089]  ? _raw_read_unlock+0x24/0x30
[  146.623110]  ? __cifsd_lookup_fd+0x82/0xd0 [cifsd]
[  146.623133]  smb2_query_info.cold+0x510/0xc4d [cifsd]
[  146.623138]  ? printk+0x96/0xb2
[  146.623142]  ? kmsg_dump_rewind+0xa5/0xa5
[  146.623146]  ? do_raw_spin_unlock+0xa3/0x130
[  146.623168]  ? smb2_query_dir+0x6d0/0x6d0 [cifsd]
[  146.623192]  ? cifsd_smb2_check_message.cold+0x24d/0x383 [cifsd]
[  146.623214]  ? cifsd_smb2_check_message.cold+0xc7/0x383 [cifsd]
[  146.623237]  handle_cifsd_work+0x2c3/0x610 [cifsd]
[  146.623260]  ? smb2_query_dir+0x6d0/0x6d0 [cifsd]
[  146.623266]  process_one_work+0x463/0x910
[  146.623271]  ? pwq_dec_nr_in_flight+0x110/0x110
[  146.623275]  ? do_raw_spin_lock+0xfa/0x1a0
[  146.623280]  worker_thread+0x70/0x5b0
[  146.623285]  kthread+0x1a8/0x200
[  146.623289]  ? process_one_work+0x910/0x910
[  146.623292]  ? kthread_create_on_node+0xa0/0xa0
[  146.623296]  ret_from_fork+0x3a/0x50

Add reference counter, which means that now we need to cifsd_fd_put()
whenever we are done with fp.

Tested with xfstest generic/011

generic/011 17s ...  41s
Ran: generic/011
Passed all 1 tests

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>