### PR TITLE
cifsd: handle APP_INSTANCE_ID durable_handle_context

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -1884,12 +1884,9 @@ static int parse_durable_handle_context(struct cifsd_work *work,
 		case APP_INSTANCE_ID:
 		{
 			struct create_app_inst_id *inst_id;
-			struct cifsd_file *fp;
 
 			inst_id = (struct create_app_inst_id *)context;
-			fp = cifsd_lookup_fd_app_id(inst_id->AppInstanceId);
-			if (fp)
-				cifsd_close_fd(work, fp->volatile_id);
+			cifsd_close_fd_app_id(work, inst_id->AppInstanceId);
 			d_info->app_id = inst_id->AppInstanceId;
 			break;
 		}

--- a/vfs_cache.h
+++ b/vfs_cache.h
@@ -179,8 +179,8 @@ struct cifsd_file *cifsd_lookup_fd_slow(struct cifsd_work *work,
 
 void cifsd_fd_put(struct cifsd_work *work, struct cifsd_file *fp);
 
+int cifsd_close_fd_app_id(struct cifsd_work *work, char *app_id);
 struct cifsd_file *cifsd_lookup_durable_fd(unsigned long long id);
-struct cifsd_file *cifsd_lookup_fd_app_id(char *app_id);
 struct cifsd_file *cifsd_lookup_fd_cguid(char *cguid);
 struct cifsd_file *cifsd_lookup_fd_filename(struct cifsd_work *work,
 					    char *filename);


### PR DESCRIPTION
APP_INSTANCE_ID durable_handle_context handling performs global ft
lookup with the purpose to do cifsd_close_fd() on found fp. Rework
it and do it in one step, respecting fp's ->refcount value.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>