### PR TITLE
cifsd: use cifsd_pr_fmt to prefix log messages

### DIFF
--- a/glob.h
+++ b/glob.h
@@ -169,16 +169,20 @@ struct cifsd_work {
 #define HAS_TRANSFORM_BUF(w)	((w)->tr_buf != NULL)
 #define TRANSFORM_BUF(w)	(void *)((w)->tr_buf)
 
+#ifndef cifsd_pr_fmt
+#define cifsd_pr_fmt(fmt)	"kcifsd: " fmt
+#endif
+
 #define cifsd_debug(fmt, ...)					\
 	do {							\
 		if (cifsd_debugging)				\
-			pr_info("kcifsd: %s:%d: " fmt,		\
+			pr_info(cifsd_pr_fmt("%s:%d: " fmt),	\
 			__func__, __LINE__, ##__VA_ARGS__);	\
 	} while (0)
 
-#define cifsd_info(fmt, ...) pr_info("kcifsd: " fmt, ##__VA_ARGS__)
+#define cifsd_info(fmt, ...) pr_info(cifsd_pr_fmt(fmt), ##__VA_ARGS__)
 
-#define cifsd_err(fmt, ...) pr_err("kcifsd: %s:%d: " fmt,	\
+#define cifsd_err(fmt, ...) pr_err(cifsd_pr_fmt("%s:%d: " fmt),	\
 			__func__, __LINE__, ##__VA_ARGS__)
 
 static inline unsigned int get_rfc1002_length(void *buf)

--- a/transport_smbd.c
+++ b/transport_smbd.c
@@ -17,6 +17,8 @@
  *   the GNU General Public License for more details.
  */
 
+#define cifsd_pr_fmt(fmt)	"kcifsd: smbd: " fmt
+
 #include <linux/kthread.h>
 #include <linux/rwlock.h>
 #include <linux/list.h>


### PR DESCRIPTION
Subsystems can re-define cifsd_pr_fmt macro to add
a prefix to a log message

Signed-off-by: Hyunchul Lee <hyc.lee@gmail.com>