### PR TITLE
cifsd: fix xfstests generic/263 failure

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -6340,12 +6340,6 @@ static int smb2_ioctl_copychunk(struct cifsd_work *work,
 			(FILE_READ_DATA_LE | FILE_GENERIC_READ_LE))) {
 		rsp->hdr.Status = STATUS_ACCESS_DENIED;
 		goto out;
-	} else if (cnt_code == FSCTL_COPYCHUNK_WRITE &&
-			dst_fp->daccess &
-			 (FILE_READ_DATA_LE |
-			FILE_GENERIC_READ_LE)) {
-		rsp->hdr.Status = STATUS_ACCESS_DENIED;
-		goto out;
 	}
 
 	ret = cifsd_vfs_copy_file_ranges(work, src_fp, dst_fp,


### PR DESCRIPTION
Fix copy_file_range failure.

Allow FSCTL_SRC_COPYCHUNK_WRITE even when the destination
file has not only write accesses but read accesses.
Windows clients seem to allow this and smbtorture does not
complain about this.

Signed-off-by: Hyunchul Lee <hyc.lee@gmail.com>