### PR TITLE
cifsd: set zero to rcv and snd timeout before socket shutdown

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -409,7 +409,7 @@ again:
 
 		task = conn->transport->handler;
 		if (task)
-			cifsd_err("Stop session handler %s/%d\n",
+			cifsd_debug("Stop session handler %s/%d\n",
 				  task->comm,
 				  task_pid_nr(task));
 		conn->status = CIFSD_SESS_EXITING;
@@ -417,7 +417,7 @@ again:
 	read_unlock(&conn_list_lock);
 
 	if (!list_empty(&conn_list)) {
-		schedule_timeout_interruptible(CIFSD_TCP_RECV_TIMEOUT / 2);
+		schedule_timeout_interruptible(HZ/10); /* 100ms */
 		goto again;
 	}
 }

--- a/server.c
+++ b/server.c
@@ -435,8 +435,12 @@ static ssize_t kill_server_store(struct class *class,
 		return len;
 
 	cifsd_err("kill command received\n");
+	mutex_lock(&ctrl_lock);
 	WRITE_ONCE(server_conf.state, SERVER_STATE_RESETTING);
-	server_queue_ctrl_reset_work();
+	__module_get(THIS_MODULE);
+	server_ctrl_handle_reset(NULL);
+	module_put(THIS_MODULE);
+	mutex_unlock(&ctrl_lock);
 	return len;
 }
 


### PR DESCRIPTION
Signed-off-by: Namjae Jeon <linkinjeon@gmail.com>
Cc: Andy Walsh <andy.walsh44@gmail.com>