### PR TITLE
ksmbd: clear shares in session destroy when kill_server is called

### DIFF
--- a/mgmt/user_session.c
+++ b/mgmt/user_session.c
@@ -150,6 +150,7 @@ void ksmbd_session_destroy(struct ksmbd_session *sess)
 	if (sess->user)
 		ksmbd_free_user(sess->user);
 
+	ksmbd_tree_conn_session_logoff(sess);
 	ksmbd_destroy_file_table(&sess->file_table);
 	ksmbd_session_rpc_clear_list(sess);
 	free_channel_list(sess);


### PR DESCRIPTION
If a new connection is made after kill_server, the old share configuration
can be used by using the previous tree id.
It can cause unintended configuration operation (follow symlink=yes/no)
Clear shares in tree list when kill_server is called

Reported-by: Fredrik Ternerot <fredrikt@axis.com>
Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>