### PR TITLE
ksmbd: downgrade oplock level if file is opened with read only

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -2803,7 +2803,10 @@ int smb2_open(struct ksmbd_work *work)
 			rc = find_same_lease_key(sess, fp->f_ci, lc);
 			if (rc)
 				goto err_out;
-		}
+		} else if (open_flags == O_RDONLY &&
+			    (req_op_level == SMB2_OPLOCK_LEVEL_BATCH ||
+			     req_op_level == SMB2_OPLOCK_LEVEL_EXCLUSIVE))
+			req_op_level = SMB2_OPLOCK_LEVEL_II;
 
 		rc = smb_grant_oplock(work, req_op_level,
 				      fp->persistent_id, fp,


### PR DESCRIPTION
Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>