### PR TITLE
ksmbd: include required signing in auto-negotiation response

### DIFF
--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -8243,16 +8243,16 @@ out:
  * smb1_is_sign_req() - handler for checking packet signing status
  * @work:	smb work containing notify command buffer
  *
- * Return:	1 if packed is signed, 0 otherwise
+ * Return:	true if packed is signed, false otherwise
  */
-int smb1_is_sign_req(struct ksmbd_work *work, unsigned int command)
+bool smb1_is_sign_req(struct ksmbd_work *work, unsigned int command)
 {
 	struct smb_hdr *rcv_hdr1 = (struct smb_hdr *)REQUEST_BUF(work);
 
 	if ((rcv_hdr1->Flags2 & SMBFLG2_SECURITY_SIGNATURE) &&
 			command != SMB_COM_SESSION_SETUP_ANDX)
-		return 1;
-	return 0;
+		return true;
+	return false;
 }
 
 /**

--- a/smb1pdu.h
+++ b/smb1pdu.h
@@ -1586,7 +1586,7 @@ extern int init_smb_rsp_hdr(struct ksmbd_work *work);
 extern uint16_t get_smb_cmd_val(struct ksmbd_work *work);
 extern void set_smb_rsp_status(struct ksmbd_work *work, __le32 err);
 extern int smb_allocate_rsp_buf(struct ksmbd_work *work);
-extern int smb1_is_sign_req(struct ksmbd_work *work, unsigned int command);
+extern bool smb1_is_sign_req(struct ksmbd_work *work, unsigned int command);
 extern int smb1_check_sign_req(struct ksmbd_work *work);
 extern void smb1_set_sign_rsp(struct ksmbd_work *work);
 extern int smb_check_user_session(struct ksmbd_work *work);

--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -286,6 +286,8 @@ int init_smb2_neg_rsp(struct ksmbd_work *work)
 		sizeof(struct smb2_hdr) - sizeof(rsp->Buffer) +
 		AUTH_GSS_LENGTH);
 	rsp->SecurityMode = SMB2_NEGOTIATE_SIGNING_ENABLED_LE;
+	if (server_conf.signing == KSMBD_CONFIG_OPT_MANDATORY)
+		rsp->SecurityMode |= SMB2_NEGOTIATE_SIGNING_REQUIRED_LE;
 	conn->use_spnego = true;
 
 	ksmbd_conn_set_need_negotiate(work);

--- a/smb2pdu.h
+++ b/smb2pdu.h
@@ -1515,7 +1515,7 @@ extern int init_smb2_neg_rsp(struct ksmbd_work *work);
 extern void smb2_set_err_rsp(struct ksmbd_work *work);
 extern int smb2_check_user_session(struct ksmbd_work *work);
 extern int smb2_get_ksmbd_tcon(struct ksmbd_work *work);
-extern int smb2_is_sign_req(struct ksmbd_work *work, unsigned int command);
+extern bool smb2_is_sign_req(struct ksmbd_work *work, unsigned int command);
 extern int smb2_check_sign_req(struct ksmbd_work *work);
 extern void smb2_set_sign_rsp(struct ksmbd_work *work);
 extern int smb3_check_sign_req(struct ksmbd_work *work);
@@ -1531,7 +1531,7 @@ extern void smb3_preauth_hash_rsp(struct ksmbd_work *work);
 extern int smb3_is_transform_hdr(void *buf);
 extern int smb3_decrypt_req(struct ksmbd_work *work);
 extern int smb3_encrypt_resp(struct ksmbd_work *work);
-extern int smb3_final_sess_setup_resp(struct ksmbd_work *work);
+extern bool smb3_11_final_sess_setup_resp(struct ksmbd_work *work);
 extern int smb2_set_rsp_credits(struct ksmbd_work *work);
 
 /* smb2 misc functions */

--- a/smb_common.h
+++ b/smb_common.h
@@ -451,7 +451,7 @@ struct smb_version_ops {
 	int (*set_rsp_credits)(struct ksmbd_work *work);
 	int (*check_user_session)(struct ksmbd_work *work);
 	int (*get_ksmbd_tcon)(struct ksmbd_work *work);
-	int (*is_sign_req)(struct ksmbd_work *work, unsigned int command);
+	bool (*is_sign_req)(struct ksmbd_work *work, unsigned int command);
 	int (*check_sign_req)(struct ksmbd_work *work);
 	void (*set_sign_rsp)(struct ksmbd_work *work);
 	int (*generate_signingkey)(struct ksmbd_session *sess);


### PR DESCRIPTION
When signing is mandatory by server configuration, include required
signing also in first negotiation response when upgrading from SMB1 to
SMB2 in auto-negotiation.

Signed-off-by: Fredrik Ternerot <fredrikt@axis.com>
Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>