### PR TITLE
cifsd: prevent NULL pointer dereference in signing handling

### DIFF
--- a/glob.h
+++ b/glob.h
@@ -14,7 +14,7 @@
 #include "vfs_cache.h"
 #include "smberr.h"
 
-#define KSMBD_VERSION	"3.2.1"
+#define KSMBD_VERSION	"3.2.2"
 
 /* @FIXME clean up this code */
 

--- a/server.c
+++ b/server.c
@@ -138,7 +138,7 @@ andx_again:
 		return TCP_HANDLER_CONTINUE;
 	}
 
-	if (conn->ops->is_sign_req(work, command)) {
+	if (work->sess && conn->ops->is_sign_req(work, command)) {
 		ret = conn->ops->check_sign_req(work);
 		if (!ret) {
 			conn->ops->set_rsp_status(work, STATUS_ACCESS_DENIED);


### PR DESCRIPTION
Make sure work->sess is not NULL when calling check_sign_req() to
prevent NULL pointer dereference. This was causing kernel panic when
using signing and pysmb (SMB1) as client.

Fixes: c670a9a0d35f ("ksmbd: verify and set signature for compound request/response")
Signed-off-by: Fredrik Ternerot <fredrikt@axis.com>
Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>