### PR TITLE
cifsd: release 3.2.3 version

### DIFF
--- a/glob.h
+++ b/glob.h
@@ -14,7 +14,7 @@
 #include "vfs_cache.h"
 #include "smberr.h"
 
-#define KSMBD_VERSION	"3.2.2"
+#define KSMBD_VERSION	"3.2.3"
 
 /* @FIXME clean up this code */
 


### PR DESCRIPTION
Major changes are:
  - rework SMB2_RETURN_SINGLE_ENTRY in smb2_query_dir
  - fix stuck issue while writing files with windows client

Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>