### PR TITLE
cifsd: release 3.2.4 version

### DIFF
--- a/glob.h
+++ b/glob.h
@@ -14,7 +14,7 @@
 #include "vfs_cache.h"
 #include "smberr.h"
 
-#define KSMBD_VERSION	"3.2.3"
+#define KSMBD_VERSION	"3.2.4"
 
 /* @FIXME clean up this code */
 


### PR DESCRIPTION
Major changes are:
 - Fix the connection failures when giving -m and -e option with smbclient.
 - Fix copy failure with local filesystem that doesn't support
   fallocate.
 - Fix negotiation failure when setting same a dialect to server min/max
   protocl parameter.

Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>