### PR TITLE
cifsd: make spnego depend on the "extended security" bit in flags2

### DIFF
--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -873,8 +873,11 @@ int smb_handle_negotiate(struct ksmbd_work *work)
 		cpu_to_le32((time & 0xFFFFFFFF00000000) >> 32);
 	neg_rsp->ServerTimeZone = 0;
 
-	/* TODO: need to set spnego enable through smb.conf parameter */
-	conn->use_spnego = true;
+	if (((struct smb_hdr *)REQUEST_BUF(work))->Flags2 & SMBFLG2_EXT_SEC)
+		conn->use_spnego = true;
+
+	ksmbd_debug(SMB, "spnego is %s\n", conn->use_spnego ? "on" : "off");
+
 	if (conn->use_spnego == false) {
 		neg_rsp->EncryptionKeyLength = CIFS_CRYPTO_KEY_SIZE;
 		neg_rsp->ByteCount = cpu_to_le16(CIFS_CRYPTO_KEY_SIZE);


### PR DESCRIPTION
The SMB header has a flag and flags2 field where the client sends the
capabilities that it supports. The server is then supposed to respond to
this accordingly.

When bit 11 is set in flags2 then "Extended Security Negotiation" is
enabled. In this case we are supposed to use spnego. When that field is
absent however spnego should be disabled.

The samba server for example does this:
  if (req->smb_conn->negotiate.encrypted_passwords &&
      (req->flags2 & FLAGS2_EXTENDED_SECURITY))
		negotiate_spnego = true;

Fixes #436 for me