### PR TITLE
cifsd: remove unneeded ksmbd_fd_put() in find_next()

### DIFF
--- a/smb1pdu.c
+++ b/smb1pdu.c
@@ -6381,7 +6381,6 @@ err_out:
 		rsp->hdr.Status.CifsError =
 			STATUS_UNEXPECTED_IO_ERROR;
 
-	ksmbd_fd_put(work, dir_fp);
 	kfree(d_info.smb1_name);
 	kfree(pathname);
 	return 0;


### PR DESCRIPTION
dir_fp is already free by ksmbd_close_fd() before ksmbd_fd_put().
Remove unneeded ksmbd_fd_put().

Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>