### PR TITLE
cifsd: open file with O_NONBLOCK flags by default

### DIFF
--- a/smb2pdu.c
+++ b/smb2pdu.c
@@ -1780,7 +1780,7 @@ out_err1:
 static int smb2_create_open_flags(bool file_present, __le32 access,
 		__le32 disposition)
 {
-	int oflags = 0;
+	int oflags = O_NONBLOCK | O_LARGEFILE;
 
 	if ((access & FILE_READ_DESIRED_ACCESS &&
 			access & FILE_WRITE_DESIRE_ACCESS) ||
@@ -2873,7 +2873,7 @@ int smb2_open(struct ksmbd_work *work)
 	}
 
 	rc = 0;
-	filp = dentry_open(&path, open_flags | O_LARGEFILE, current_cred());
+	filp = dentry_open(&path, open_flags, current_cred());
 	if (IS_ERR(filp)) {
 		rc = PTR_ERR(filp);
 		ksmbd_err("dentry open for dir failed, rc %d\n", rc);


### PR DESCRIPTION
If you use the ls command in directory containing the pipe file
through the cifs client, There is an issue that is blocked in
dentry_open(). The file open is blocked if openning with O_RDONLY.
cifs client calls smb2 open after query dirty for the smb2 get info,
and blocking in smb2_open occurs. There is no need to block from
smb2 open on the server. blocking for pipe file will have to be done
by the client.

Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>